### PR TITLE
Create ScannerClass for frame-based MRZ scanning

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "b5bea232a19fa1828496940f95df5bb0c345b8406167528df18047889ed566eb",
+  "originHash" : "68c85fb1665a4f4a7990a843c789196b56807fed47267327e8d74912e63ab60b",
   "pins" : [
     {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "5928286acce13def418ec36d05a001a9641086f2",
-        "version" : "1.0.3"
+        "revision" : "fd16d76fd8b9a976d88bfb6cacc05ca8d19c91b6",
+        "version" : "1.1.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
-        "version" : "1.3.1"
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump.git",
       "state" : {
-        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
-        "version" : "1.3.3"
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "4c90d6b2b9bf0911af87b103bb40f41771891596",
-        "version" : "1.9.2"
+        "revision" : "c79f72b3e67a1eb64f66f76704c22ed6a5c1ed84",
+        "version" : "1.11.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
-        "version" : "1.5.2"
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/romanmazeev/MRZParser.git", from: "1.4.3"),
-        .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.9.2"),
-        .package(url: "https://github.com/pointfreeco/swift-custom-dump.git", from: "1.3.3")
+        .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.11.0"),
+        .package(url: "https://github.com/pointfreeco/swift-custom-dump.git", from: "1.5.0")
     ],
     targets: [
         .target(

--- a/Sources/MRZScanner/Public/Scanner.swift
+++ b/Sources/MRZScanner/Public/Scanner.swift
@@ -11,6 +11,25 @@ import Vision
 
 // MARK: - Image stream scanning
 
+public final class Scanner: Sendable {
+    private let tracker: any TrackerProtocol
+
+    public init() {
+        @Dependency(\.tracker.create) var createTracker
+        self.tracker = createTracker()
+    }
+
+    public func scanFrame(image: CIImage, configuration: ScanningConfiguration) async throws -> ScanningResult<TrackerResult> {
+        let (parsedResult, boundingRects) = try await scanMRZCode(from: image, configuration: configuration)
+        guard let parsedResult else {
+            return ScanningResult<TrackerResult>(results: tracker.seenResults, boundingRects: boundingRects)
+        }
+
+        tracker.track(result: parsedResult)
+        return .init(results: tracker.seenResults, boundingRects: boundingRects)
+    }
+}
+
 @available(macOS 15.0, iOS 18.0, *)
 public extension AsyncSequence<CIImage, Never> {
     func scanForMRZCode(configuration: ScanningConfiguration) -> any AsyncSequence<ScanningResult<TrackerResult>, Error> {

--- a/Sources/MRZScanner/Public/Scanner.swift
+++ b/Sources/MRZScanner/Public/Scanner.swift
@@ -30,7 +30,7 @@ public final class Scanner: Sendable {
     }
 }
 
-@available(macOS 15.0, iOS 18.0, *)
+@available(macOS 15.0, iOS 18.0, tvOS 18, *)
 public extension AsyncSequence<CIImage, Never> {
     func scanForMRZCode(configuration: ScanningConfiguration) -> any AsyncSequence<ScanningResult<TrackerResult>, Error> {
         @Dependency(\.tracker.create) var createTracker

--- a/Tests/MRZScannerTests/Public/ScannerTests.swift
+++ b/Tests/MRZScannerTests/Public/ScannerTests.swift
@@ -121,6 +121,229 @@ final class MRZScannerTests: XCTestCase {
         )
     }
 
+    // MARK: - Scanner.scanFrame
+
+    func testScanFrameSuccess() async throws {
+        let events = LockIsolated([Event]())
+        let trackerMock = TrackerMock()
+        trackerMock.onSeenResultsCall.withValue {
+            $0 = {
+                events.withValue { $0.append(.seenResults) }
+            }
+        }
+        trackerMock.onTrackCall.withValue {
+            $0 = { parserResult in
+                events.withValue { $0.append(.track(parserResult)) }
+            }
+        }
+
+        try await withDependencies {
+            $0.textRecognizer.recognize = { @Sendable configuration, scanningImage in
+                events.withValue { $0.append(.recognize(configuration, scanningImage.base64EncodedString.count)) }
+                return [.mock]
+            }
+            $0.validator.getValidatedResults = { @Sendable possibleLines in
+                events.withValue { $0.append(.getValidatedResults(possibleLines)) }
+                return [.mock]
+            }
+            $0.boundingRectConverter.convert = { @Sendable results, validLines in
+                events.withValue { $0.append(.convert(results, validLines)) }
+                return .mock
+            }
+            $0.parser.parse = { @Sendable mrzLines in
+                events.withValue { $0.append(.parse(mrzLines)) }
+                return .mock
+            }
+            $0.tracker.create = { @Sendable in
+                events.withValue { $0.append(.createTracker) }
+                return trackerMock
+            }
+        } operation: {
+            let scanner = Scanner()
+            let result = try await scanner.scanFrame(
+                image: try XCTUnwrap(CIImage(data: .imageMock)),
+                configuration: .mock()
+            )
+            XCTAssertEqual(result.results, .mock)
+            XCTAssertEqual(result.boundingRects, .mock)
+        }
+
+        expectNoDifference(
+            events.value,
+            [
+                .createTracker,
+                .recognize(.mock(), 1348268),
+                .getValidatedResults([["test"]]),
+                .convert([.mock], [.mock]),
+                .parse(["test"]),
+                .track(.mock),
+                .seenResults
+            ]
+        )
+    }
+
+    func testScanFrameParsingFailure() async throws {
+        let events = LockIsolated([Event]())
+        let trackerMock = TrackerMock()
+        trackerMock.onSeenResultsCall.withValue {
+            $0 = {
+                events.withValue { $0.append(.seenResults) }
+            }
+        }
+        trackerMock.onTrackCall.withValue {
+            $0 = { parserResult in
+                events.withValue { $0.append(.track(parserResult)) }
+            }
+        }
+
+        try await withDependencies {
+            $0.textRecognizer.recognize = { @Sendable configuration, scanningImage in
+                events.withValue { $0.append(.recognize(configuration, scanningImage.base64EncodedString.count)) }
+                return [.mock]
+            }
+            $0.validator.getValidatedResults = { @Sendable possibleLines in
+                events.withValue { $0.append(.getValidatedResults(possibleLines)) }
+                return [.mock]
+            }
+            $0.boundingRectConverter.convert = { @Sendable results, validLines in
+                events.withValue { $0.append(.convert(results, validLines)) }
+                return .mock
+            }
+            $0.parser.parse = { @Sendable mrzLines in
+                events.withValue { $0.append(.parse(mrzLines)) }
+                return nil
+            }
+            $0.tracker.create = { @Sendable in
+                events.withValue { $0.append(.createTracker) }
+                return trackerMock
+            }
+        } operation: {
+            let scanner = Scanner()
+            let result = try await scanner.scanFrame(
+                image: try XCTUnwrap(CIImage(data: .imageMock)),
+                configuration: .mock()
+            )
+            XCTAssertEqual(result.results, .mock)
+            XCTAssertEqual(result.boundingRects, .mock)
+        }
+
+        expectNoDifference(
+            events.value,
+            [
+                .createTracker,
+                .recognize(.mock(), 1348268),
+                .getValidatedResults([["test"]]),
+                .convert([.mock], [.mock]),
+                .parse(["test"]),
+                .seenResults
+            ]
+        )
+    }
+
+    func testScanFrameTextRecognizerFailure() async throws {
+        let events = LockIsolated([Event]())
+
+        try await withDependencies {
+            $0.textRecognizer.recognize = { @Sendable configuration, scanningImage in
+                events.withValue { $0.append(.recognize(configuration, scanningImage.base64EncodedString.count)) }
+                throw MockError.mock
+            }
+            $0.tracker.create = { @Sendable in
+                events.withValue { $0.append(.createTracker) }
+                return TrackerMock()
+            }
+        } operation: {
+            let scanner = Scanner()
+            do {
+                _ = try await scanner.scanFrame(
+                    image: try XCTUnwrap(CIImage(data: .imageMock)),
+                    configuration: .mock()
+                )
+                XCTFail("Should fail here")
+            } catch {
+                XCTAssertEqual(try XCTUnwrap(error as? MockError), .mock)
+            }
+        }
+
+        expectNoDifference(
+            events.value,
+            [
+                .createTracker,
+                .recognize(.mock(), 1348268)
+            ]
+        )
+    }
+
+    func testScanFrameSuccessTwice() async throws {
+        let events = LockIsolated([Event]())
+        let trackerMock = TrackerMock()
+        trackerMock.onSeenResultsCall.withValue {
+            $0 = {
+                events.withValue { $0.append(.seenResults) }
+            }
+        }
+        trackerMock.onTrackCall.withValue {
+            $0 = { parserResult in
+                events.withValue { $0.append(.track(parserResult)) }
+            }
+        }
+
+        try await withDependencies {
+            $0.textRecognizer.recognize = { @Sendable configuration, scanningImage in
+                events.withValue { $0.append(.recognize(configuration, scanningImage.base64EncodedString.count)) }
+                return [.mock]
+            }
+            $0.validator.getValidatedResults = { @Sendable possibleLines in
+                events.withValue { $0.append(.getValidatedResults(possibleLines)) }
+                return [.mock]
+            }
+            $0.boundingRectConverter.convert = { @Sendable results, validLines in
+                events.withValue { $0.append(.convert(results, validLines)) }
+                return .mock
+            }
+            $0.parser.parse = { @Sendable mrzLines in
+                events.withValue { $0.append(.parse(mrzLines)) }
+                return .mock
+            }
+            $0.tracker.create = { @Sendable in
+                events.withValue { $0.append(.createTracker) }
+                return trackerMock
+            }
+        } operation: {
+            let scanner = Scanner()
+            let image = try XCTUnwrap(CIImage(data: .imageMock))
+
+            let firstResult = try await scanner.scanFrame(image: image, configuration: .mock())
+            XCTAssertEqual(firstResult.results, .mock)
+            XCTAssertEqual(firstResult.boundingRects, .mock)
+
+            let secondResult = try await scanner.scanFrame(image: image, configuration: .mock())
+            XCTAssertEqual(secondResult.results, .mock)
+            XCTAssertEqual(secondResult.boundingRects, .mock)
+        }
+
+        expectNoDifference(
+            events.value,
+            [
+                .createTracker,
+                .recognize(.mock(), 1348268),
+                .getValidatedResults([["test"]]),
+                .convert([.mock], [.mock]),
+                .parse(["test"]),
+                .track(.mock),
+                .seenResults,
+                .recognize(.mock(), 1348268),
+                .getValidatedResults([["test"]]),
+                .convert([.mock], [.mock]),
+                .parse(["test"]),
+                .track(.mock),
+                .seenResults
+            ]
+        )
+    }
+
+    // MARK: - AsyncStream image stream
+
     func testImageStreamSuccess() async throws {
         let events = LockIsolated([Event]())
         let trackerMock = TrackerMock()


### PR DESCRIPTION
This pull request introduces a new `Scanner` class for frame-based MRZ scanning and adds comprehensive unit tests for its behavior. It also updates dependency versions to ensure compatibility and stability. The most significant changes are grouped below by theme.

Scanner API enhancements:

* Introduced a new `Scanner` class with a `scanFrame` method for scanning individual images and tracking results, leveraging dependency injection for tracker creation. (`Sources/MRZScanner/Public/Scanner.swift`)

Testing improvements:

* Added extensive unit tests for the new `Scanner.scanFrame` method, covering success, parsing failure, text recognition failure, and repeated invocations to verify correct tracker and result handling. (`Tests/MRZScannerTests/Public/ScannerTests.swift`)

Dependency updates:

* Updated `swift-dependencies` and `swift-custom-dump` package versions in `Package.swift` to ensure compatibility with the latest features and bug fixes. (`Package.swift`)